### PR TITLE
Fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ https://github.com/caskroom/homebrew-cask/pull/41890
 
 ## How do I install these Casks?
 
-`brew install sscotth/sip/<cask>`
+`brew cask install sscotth/sip/<cask>`
 
-Or `brew tap sscotth/sip` and then `brew install <cask>`.
+Or `brew tap sscotth/sip` and then `brew cask install <cask>`.
 
 Or install via URL (which will not receive updates):
 
 ```
-brew install https://raw.githubusercontent.com/sscotth/homebrew-sip/master/Casks/<cask>.rb
+brew cask install https://raw.githubusercontent.com/sscotth/homebrew-sip/master/Casks/<cask>.rb
 ```
 
 ## Documentation


### PR DESCRIPTION
`brew install ...` does not work for casks. The `cask` keyword is required.


Tested using:

    $ brew --version
    Homebrew 1.8.3
    Homebrew/homebrew-core (git revision a266; last commit 2018-11-22)
    Homebrew/homebrew-cask (git revision c1679; last commit 2018-11-22)